### PR TITLE
if empty body, iOS crashed

### DIFF
--- a/flow/net/cocoa/request.rb
+++ b/flow/net/cocoa/request.rb
@@ -53,7 +53,7 @@ module Net
     end
 
     def build_body(body)
-      return body.to_json.to_data if json?
+      return body.to_json.to_data if json? and body != ''
       body.to_data
     end
 


### PR DESCRIPTION
When a get request with the content type of JSON has an empty body the application would crash. This should not happen, the developer is forced to remove the content type which doesn't make sense. While on Android it would work fine. This at least brings consistency in that regard.

Here is the code that would crash an iOS application
```ruby
    session = Net.build('https://httpbin.org') do
      header(:content_type, :json)
    end

    reachability = Net.reachable?('httpbin.org') { |reachable|
      if reachable
        session.get('/ip') { |response|
          puts 'success'
        }
      else
        puts 'host is down!'
      end
    }

    reachability.stop